### PR TITLE
Fix to `instances` array in script view

### DIFF
--- a/packages/sterling/src/components/ScriptView/alloy-proxy/AlloyInstance.ts
+++ b/packages/sterling/src/components/ScriptView/alloy-proxy/AlloyInstance.ts
@@ -49,7 +49,7 @@ class AlloyInstance {
     this._filename = '';
     this._sources = new Map();
 
-    if (text) this._buildFromXML(text);
+    if (text) this._buildFromXML(text, index);
   }
 
   /**


### PR DESCRIPTION
Pass `index` in the AlloyInstance constructor; this fixes a prior
issue where the `instances` array would contain only copies of the
first state in a given trace.