### PR TITLE
Fix: minimap not showing for loopback 0 traces

### DIFF
--- a/packages/alloy-instance/src/xml.ts
+++ b/packages/alloy-instance/src/xml.ts
@@ -12,7 +12,7 @@ export function parseAlloyXML(xml: string): AlloyDatum {
     bitwidth: parseNumericAttribute(instances[0], 'bitwidth'),
     command: parseStringAttribute(instances[0], 'command'),
     loopBack:
-      parseNumericAttribute(instances[0], 'backloop') ||
+      parseNumericAttribute(instances[0], 'backloop') ??
       // TODO: Remove this hack once forge is fixed
       parseNumericAttribute(instances[0], 'loop'),
     maxSeq: parseNumericAttribute(instances[0], 'maxseq'),

--- a/packages/sterling/src/components/ScriptView/alloy-proxy/AlloyInstance.ts
+++ b/packages/sterling/src/components/ScriptView/alloy-proxy/AlloyInstance.ts
@@ -49,7 +49,7 @@ class AlloyInstance {
     this._filename = '';
     this._sources = new Map();
 
-    if (text) this._buildFromXML(text);
+    if (text) this._buildFromXML(text, index);
   }
 
   /**


### PR DESCRIPTION
Since 0 is falsey in JavaScript, we need to use the ?? operator, not the || operator.